### PR TITLE
Add TableViewReorderDelegate tableView(_:targetIndexPathForMoveFromRowAt:to)

### DIFF
--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -35,7 +35,8 @@ extension ReorderController {
     func updateDestinationRow() {
         guard case .reordering(let context) = reorderState,
             let tableView = tableView,
-            let newDestinationRow = newDestinationRow(),
+            let proposedNewDestinationRow = newDestinationRow(),
+            let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForMoveFromRowAt: context.sourceRow, to: proposedNewDestinationRow),
             newDestinationRow != context.destinationRow
         else { return }
         

--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -119,8 +119,7 @@ extension ReorderController {
         }
         
         let snapDistances = rowSnapDistances + sectionSnapDistances
-        let availableSnapDistances = snapDistances.filter { delegate.tableView(tableView, canReorderRowAt: $0.path) != false }
-        return availableSnapDistances.min(by: { $0.distance < $1.distance })?.path
+        return snapDistances.min(by: { $0.distance < $1.distance })?.path
     }
     
     func rectForEmptySection(_ section: Int) -> CGRect {

--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -36,7 +36,7 @@ extension ReorderController {
         guard case .reordering(let context) = reorderState,
             let tableView = tableView,
             let proposedNewDestinationRow = proposedNewDestinationRow(),
-            let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForMoveFromRowAt: context.sourceRow, to: proposedNewDestinationRow),
+            let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForMoveFromRowAt: context.destinationRow, to: proposedNewDestinationRow),
             newDestinationRow != context.destinationRow
         else { return }
         

--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -35,7 +35,7 @@ extension ReorderController {
     func updateDestinationRow() {
         guard case .reordering(let context) = reorderState,
             let tableView = tableView,
-            let proposedNewDestinationRow = newDestinationRow(),
+            let proposedNewDestinationRow = proposedNewDestinationRow(),
             let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForMoveFromRowAt: context.sourceRow, to: proposedNewDestinationRow),
             newDestinationRow != context.destinationRow
         else { return }
@@ -52,7 +52,7 @@ extension ReorderController {
         tableView.endUpdates()
     }
     
-    func newDestinationRow() -> IndexPath? {
+    func proposedNewDestinationRow() -> IndexPath? {
         guard case .reordering(let context) = reorderState,
             let tableView = tableView,
             let superview = tableView.superview,

--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -36,7 +36,7 @@ extension ReorderController {
         guard case .reordering(let context) = reorderState,
             let tableView = tableView,
             let proposedNewDestinationRow = proposedNewDestinationRow(),
-            let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForMoveFromRowAt: context.destinationRow, to: proposedNewDestinationRow),
+            let newDestinationRow = delegate?.tableView(tableView, targetIndexPathForReorderFromRowAt: context.destinationRow, to: proposedNewDestinationRow),
             newDestinationRow != context.destinationRow
         else { return }
         

--- a/Source/ReorderController.swift
+++ b/Source/ReorderController.swift
@@ -58,6 +58,14 @@ public protocol TableViewReorderDelegate: class {
     func tableView(_ tableView: UITableView, canReorderRowAt indexPath: IndexPath) -> Bool
     
     /**
+     When attempting to move a row from a sourceIndexPath to a proposedDestinationIndexPath, asks the reorder delegate what the actual targetIndexPath should be. This allows the reorder delegate to selectively allow or modify reordering between sections or groups of rows, for example.
+     - Parameter tableView: The table view requesting this information.
+     - Parameter sourceIndexPath: The original index path of the row to be moved.
+     - Parameter proposedDestinationIndexPath: The potential index path of the row's new location.
+     */
+    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath
+
+    /**
      Tells the delegate that the user has begun reordering a row.
      - Parameter tableView: The table view providing this information.
      */
@@ -79,6 +87,10 @@ public extension TableViewReorderDelegate {
         return true
     }
     
+    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        return proposedDestinationIndexPath
+    }
+
     func tableViewDidBeginReordering(_ tableView: UITableView) {
     }
     

--- a/Source/ReorderController.swift
+++ b/Source/ReorderController.swift
@@ -63,7 +63,7 @@ public protocol TableViewReorderDelegate: class {
      - Parameter sourceIndexPath: The original index path of the row to be moved.
      - Parameter proposedDestinationIndexPath: The potential index path of the row's new location.
      */
-    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath
+    func tableView(_ tableView: UITableView, targetIndexPathForReorderFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath
 
     /**
      Tells the delegate that the user has begun reordering a row.
@@ -87,7 +87,7 @@ public extension TableViewReorderDelegate {
         return true
     }
     
-    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath {
+    func tableView(_ tableView: UITableView, targetIndexPathForReorderFromRowAt sourceIndexPath: IndexPath, to proposedDestinationIndexPath: IndexPath) -> IndexPath {
         return proposedDestinationIndexPath
     }
 


### PR DESCRIPTION
This TableViewReorderDelegate method optionally gives the reorder delegate an opportunity to selectively allow or modify reordering between sections or groups of rows. This is equivalent to the UITableViewDelegate method tableView(targetIndexPathForMoveFromRowAt:toProposedIndexPath:). Let me know if a sample project demonstrating this capability would be helpful, or if this functionality is already possible using the existing codebase.