### PR TITLE
Carthage support

### DIFF
--- a/Example/BasicViewController.swift
+++ b/Example/BasicViewController.swift
@@ -21,6 +21,7 @@
 //
 
 import UIKit
+import SwiftReorder
 
 class BasicViewController: UITableViewController {
     

--- a/Example/EffectsViewController.swift
+++ b/Example/EffectsViewController.swift
@@ -21,6 +21,7 @@
 //
 
 import UIKit
+import SwiftReorder
 
 class EffectsViewController: UITableViewController {
     

--- a/Example/GroupedViewController.swift
+++ b/Example/GroupedViewController.swift
@@ -21,6 +21,7 @@
 //
 
 import UIKit
+import SwiftReorder
 
 class GroupedViewController: UITableViewController {
     

--- a/Example/LongListViewController.swift
+++ b/Example/LongListViewController.swift
@@ -21,6 +21,7 @@
 //
 
 import UIKit
+import SwiftReorder
 
 class LongListViewController: UITableViewController {
     

--- a/Example/NonMovableViewController.swift
+++ b/Example/NonMovableViewController.swift
@@ -21,6 +21,7 @@
 //
 
 import UIKit
+import SwiftReorder
 
 class NonMovableViewController: UITableViewController {
     

--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ To integrate SwiftReorder into your Xcode project using CocoaPods, specify it in
 pod 'SwiftReorder', '~> 5.0'
 ```
 
+### Carthage
+
+To integrate SwiftReorder into your Xcode project using Carthage, specify it in your `Cartfile`:
+
+```
+github "adamshin/SwiftReorder" ~> 5.0
+```
+
+Remember to [add SwiftReorder to your Carthage build phase](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos):
+
+```
+$(SRCROOT)/Carthage/Build/iOS/SwiftReorder.framework
+```
+
+and
+
+```
+$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SwiftReorder.framework
+```
+
 ### Manually
 
 You can integrate SwiftReorder into your project manually by copying the contents of the `Source` folder into your project.

--- a/SwiftReorder.xcodeproj/project.pbxproj
+++ b/SwiftReorder.xcodeproj/project.pbxproj
@@ -7,10 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		66DF25141D8080A000C19289 /* ReorderController+AutoScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25101D8080A000C19289 /* ReorderController+AutoScroll.swift */; };
-		66DF25151D8080A000C19289 /* ReorderController+DestinationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25111D8080A000C19289 /* ReorderController+DestinationRow.swift */; };
-		66DF25161D8080A000C19289 /* ReorderController+GestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25121D8080A000C19289 /* ReorderController+GestureRecognizer.swift */; };
-		66DF25171D8080A000C19289 /* ReorderController+SnapshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25131D8080A000C19289 /* ReorderController+SnapshotView.swift */; };
 		66FC50F11D5EE49D00CFCCCE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50E81D5EE49D00CFCCCE /* AppDelegate.swift */; };
 		66FC50F21D5EE49D00CFCCCE /* BasicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50E91D5EE49D00CFCCCE /* BasicViewController.swift */; };
 		66FC50F41D5EE49D00CFCCCE /* EffectsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50EB1D5EE49D00CFCCCE /* EffectsViewController.swift */; };
@@ -18,12 +14,43 @@
 		66FC50F71D5EE49D00CFCCCE /* LongListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50EE1D5EE49D00CFCCCE /* LongListViewController.swift */; };
 		66FC50F81D5EE49D00CFCCCE /* NonMovableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50EF1D5EE49D00CFCCCE /* NonMovableViewController.swift */; };
 		66FC50F91D5EE49D00CFCCCE /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50F01D5EE49D00CFCCCE /* RootViewController.swift */; };
-		66FC50FB1D5EE4CA00CFCCCE /* UITableView+Reorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50FA1D5EE4CA00CFCCCE /* UITableView+Reorder.swift */; };
-		66FC50FD1D5EE4D600CFCCCE /* ReorderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50FC1D5EE4D600CFCCCE /* ReorderController.swift */; };
+		D9DAD5E12134663E00484E71 /* SwiftReorder.h in Headers */ = {isa = PBXBuildFile; fileRef = D9DAD5DF2134663E00484E71 /* SwiftReorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9DAD5E42134663E00484E71 /* SwiftReorder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9DAD5DD2134663E00484E71 /* SwiftReorder.framework */; };
+		D9DAD5E52134663E00484E71 /* SwiftReorder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D9DAD5DD2134663E00484E71 /* SwiftReorder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D9DAD5EA2134668200484E71 /* UITableView+Reorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50FA1D5EE4CA00CFCCCE /* UITableView+Reorder.swift */; };
+		D9DAD5EB2134668200484E71 /* ReorderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FC50FC1D5EE4D600CFCCCE /* ReorderController.swift */; };
+		D9DAD5EC2134668200484E71 /* ReorderController+SnapshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25131D8080A000C19289 /* ReorderController+SnapshotView.swift */; };
+		D9DAD5ED2134668200484E71 /* ReorderController+DestinationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25111D8080A000C19289 /* ReorderController+DestinationRow.swift */; };
+		D9DAD5EE2134668200484E71 /* ReorderController+AutoScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25101D8080A000C19289 /* ReorderController+AutoScroll.swift */; };
+		D9DAD5EF2134668200484E71 /* ReorderController+GestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DF25121D8080A000C19289 /* ReorderController+GestureRecognizer.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		D9DAD5E22134663E00484E71 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6602568B1CE6A5170029CB5F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D9DAD5DC2134663E00484E71;
+			remoteInfo = SwiftReorder;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D9DAD5E92134663E00484E71 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D9DAD5E52134663E00484E71 /* SwiftReorder.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		660256931CE6A5170029CB5F /* SwiftReorder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftReorder.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		660256931CE6A5170029CB5F /* SwiftReorderExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftReorderExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		66DF25101D8080A000C19289 /* ReorderController+AutoScroll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ReorderController+AutoScroll.swift"; path = "Source/ReorderController+AutoScroll.swift"; sourceTree = "<group>"; };
 		66DF25111D8080A000C19289 /* ReorderController+DestinationRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ReorderController+DestinationRow.swift"; path = "Source/ReorderController+DestinationRow.swift"; sourceTree = "<group>"; };
 		66DF25121D8080A000C19289 /* ReorderController+GestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ReorderController+GestureRecognizer.swift"; path = "Source/ReorderController+GestureRecognizer.swift"; sourceTree = "<group>"; };
@@ -38,10 +65,21 @@
 		66FC50F01D5EE49D00CFCCCE /* RootViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootViewController.swift; path = Example/RootViewController.swift; sourceTree = SOURCE_ROOT; };
 		66FC50FA1D5EE4CA00CFCCCE /* UITableView+Reorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UITableView+Reorder.swift"; path = "Source/UITableView+Reorder.swift"; sourceTree = "<group>"; };
 		66FC50FC1D5EE4D600CFCCCE /* ReorderController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReorderController.swift; path = Source/ReorderController.swift; sourceTree = "<group>"; };
+		D9DAD5DD2134663E00484E71 /* SwiftReorder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftReorder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9DAD5DF2134663E00484E71 /* SwiftReorder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftReorder.h; sourceTree = "<group>"; };
+		D9DAD5E02134663E00484E71 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		660256901CE6A5170029CB5F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9DAD5E42134663E00484E71 /* SwiftReorder.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D9DAD5D92134663E00484E71 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -56,6 +94,7 @@
 			children = (
 				660256A81CE6A72F0029CB5F /* Source */,
 				660256951CE6A5170029CB5F /* Example */,
+				D9DAD5DE2134663E00484E71 /* SwiftReorder */,
 				660256941CE6A5170029CB5F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -63,7 +102,8 @@
 		660256941CE6A5170029CB5F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				660256931CE6A5170029CB5F /* SwiftReorder.app */,
+				660256931CE6A5170029CB5F /* SwiftReorderExample.app */,
+				D9DAD5DD2134663E00484E71 /* SwiftReorder.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -96,16 +136,56 @@
 			name = Source;
 			sourceTree = "<group>";
 		};
+		D9DAD5DE2134663E00484E71 /* SwiftReorder */ = {
+			isa = PBXGroup;
+			children = (
+				D9DAD5DF2134663E00484E71 /* SwiftReorder.h */,
+				D9DAD5E02134663E00484E71 /* Info.plist */,
+			);
+			path = SwiftReorder;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		D9DAD5DA2134663E00484E71 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9DAD5E12134663E00484E71 /* SwiftReorder.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		660256921CE6A5170029CB5F /* SwiftReorder */ = {
+		660256921CE6A5170029CB5F /* SwiftReorderExample */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 660256A51CE6A5170029CB5F /* Build configuration list for PBXNativeTarget "SwiftReorder" */;
+			buildConfigurationList = 660256A51CE6A5170029CB5F /* Build configuration list for PBXNativeTarget "SwiftReorderExample" */;
 			buildPhases = (
 				6602568F1CE6A5170029CB5F /* Sources */,
 				660256901CE6A5170029CB5F /* Frameworks */,
 				660256911CE6A5170029CB5F /* Resources */,
+				D9DAD5E92134663E00484E71 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D9DAD5E32134663E00484E71 /* PBXTargetDependency */,
+			);
+			name = SwiftReorderExample;
+			productName = SwiftReorder;
+			productReference = 660256931CE6A5170029CB5F /* SwiftReorderExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D9DAD5DC2134663E00484E71 /* SwiftReorder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D9DAD5E82134663E00484E71 /* Build configuration list for PBXNativeTarget "SwiftReorder" */;
+			buildPhases = (
+				D9DAD5D82134663E00484E71 /* Sources */,
+				D9DAD5D92134663E00484E71 /* Frameworks */,
+				D9DAD5DA2134663E00484E71 /* Headers */,
+				D9DAD5DB2134663E00484E71 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -113,8 +193,8 @@
 			);
 			name = SwiftReorder;
 			productName = SwiftReorder;
-			productReference = 660256931CE6A5170029CB5F /* SwiftReorder.app */;
-			productType = "com.apple.product-type.application";
+			productReference = D9DAD5DD2134663E00484E71 /* SwiftReorder.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -129,6 +209,10 @@
 					660256921CE6A5170029CB5F = {
 						CreatedOnToolsVersion = 7.3;
 						LastSwiftMigration = 0920;
+					};
+					D9DAD5DC2134663E00484E71 = {
+						CreatedOnToolsVersion = 9.4.1;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -145,13 +229,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				660256921CE6A5170029CB5F /* SwiftReorder */,
+				660256921CE6A5170029CB5F /* SwiftReorderExample */,
+				D9DAD5DC2134663E00484E71 /* SwiftReorder */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		660256911CE6A5170029CB5F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D9DAD5DB2134663E00484E71 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -166,22 +258,37 @@
 			buildActionMask = 2147483647;
 			files = (
 				66FC50F91D5EE49D00CFCCCE /* RootViewController.swift in Sources */,
-				66DF25161D8080A000C19289 /* ReorderController+GestureRecognizer.swift in Sources */,
-				66FC50FD1D5EE4D600CFCCCE /* ReorderController.swift in Sources */,
-				66DF25141D8080A000C19289 /* ReorderController+AutoScroll.swift in Sources */,
 				66FC50F81D5EE49D00CFCCCE /* NonMovableViewController.swift in Sources */,
-				66DF25151D8080A000C19289 /* ReorderController+DestinationRow.swift in Sources */,
 				66FC50F11D5EE49D00CFCCCE /* AppDelegate.swift in Sources */,
 				66FC50F71D5EE49D00CFCCCE /* LongListViewController.swift in Sources */,
-				66FC50FB1D5EE4CA00CFCCCE /* UITableView+Reorder.swift in Sources */,
-				66DF25171D8080A000C19289 /* ReorderController+SnapshotView.swift in Sources */,
 				66FC50F51D5EE49D00CFCCCE /* GroupedViewController.swift in Sources */,
 				66FC50F21D5EE49D00CFCCCE /* BasicViewController.swift in Sources */,
 				66FC50F41D5EE49D00CFCCCE /* EffectsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D9DAD5D82134663E00484E71 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9DAD5EA2134668200484E71 /* UITableView+Reorder.swift in Sources */,
+				D9DAD5EF2134668200484E71 /* ReorderController+GestureRecognizer.swift in Sources */,
+				D9DAD5EE2134668200484E71 /* ReorderController+AutoScroll.swift in Sources */,
+				D9DAD5ED2134668200484E71 /* ReorderController+DestinationRow.swift in Sources */,
+				D9DAD5EC2134668200484E71 /* ReorderController+SnapshotView.swift in Sources */,
+				D9DAD5EB2134668200484E71 /* ReorderController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D9DAD5E32134663E00484E71 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D9DAD5DC2134663E00484E71 /* SwiftReorder */;
+			targetProxy = D9DAD5E22134663E00484E71 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		660256A31CE6A5170029CB5F /* Debug */ = {
@@ -293,6 +400,8 @@
 		660256A61CE6A5170029CB5F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = adamshin.SwiftReorder;
@@ -305,12 +414,73 @@
 		660256A71CE6A5170029CB5F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = adamshin.SwiftReorder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		D9DAD5E62134663E00484E71 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = SwiftReorder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = adamshin.SwiftReorder.SwiftReorder;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D9DAD5E72134663E00484E71 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = SwiftReorder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = adamshin.SwiftReorder.SwiftReorder;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -326,11 +496,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		660256A51CE6A5170029CB5F /* Build configuration list for PBXNativeTarget "SwiftReorder" */ = {
+		660256A51CE6A5170029CB5F /* Build configuration list for PBXNativeTarget "SwiftReorderExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				660256A61CE6A5170029CB5F /* Debug */,
 				660256A71CE6A5170029CB5F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D9DAD5E82134663E00484E71 /* Build configuration list for PBXNativeTarget "SwiftReorder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D9DAD5E62134663E00484E71 /* Debug */,
+				D9DAD5E72134663E00484E71 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftReorder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwiftReorder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SwiftReorder.xcodeproj/xcshareddata/xcschemes/SwiftReorder.xcscheme
+++ b/SwiftReorder.xcodeproj/xcshareddata/xcschemes/SwiftReorder.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D9DAD5DC2134663E00484E71"
+               BuildableName = "SwiftReorder.framework"
+               BlueprintName = "SwiftReorder"
+               ReferencedContainer = "container:SwiftReorder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D9DAD5DC2134663E00484E71"
+            BuildableName = "SwiftReorder.framework"
+            BlueprintName = "SwiftReorder"
+            ReferencedContainer = "container:SwiftReorder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D9DAD5DC2134663E00484E71"
+            BuildableName = "SwiftReorder.framework"
+            BlueprintName = "SwiftReorder"
+            ReferencedContainer = "container:SwiftReorder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftReorder/Info.plist
+++ b/SwiftReorder/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/SwiftReorder/SwiftReorder.h
+++ b/SwiftReorder/SwiftReorder.h
@@ -1,0 +1,19 @@
+//
+//  SwiftReorder.h
+//  SwiftReorder
+//
+//  Created by Joseph Duffy on 27/08/2018.
+//  Copyright © 2018 Adam Shin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for SwiftReorder.
+FOUNDATION_EXPORT double SwiftReorderVersionNumber;
+
+//! Project version string for SwiftReorder.
+FOUNDATION_EXPORT const unsigned char SwiftReorderVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <SwiftReorder/PublicHeader.h>
+
+


### PR DESCRIPTION
This adds support for Carthage by adding a new `SwiftReorder` framework and a shared `SwiftReorder` scheme.

I have also updated the app name to `SwiftReorderExample`; Xcode will not allow both an app and a framework target with the same name.

I have also updated the README to have instructions for installing via Carthage