### PR TITLE
Added ability to set cancelsTouchesInView for reorderGestureRecognizer.

### DIFF
--- a/Source/ReorderController.swift
+++ b/Source/ReorderController.swift
@@ -123,6 +123,12 @@ public class ReorderController: NSObject {
         }
     }
     
+    public var cancelsTouchesInView: Bool = false {
+        didSet {
+            reorderGestureRecognizer.cancelsTouchesInView = cancelsTouchesInView
+        }
+    }
+    
     /// The duration of the cell selection animation.
     public var animationDuration: TimeInterval = 0.2
     


### PR DESCRIPTION
I have added the ability to set cancelsTouchesInView for the reorderGestureRecognizer. This was to fix an issue where didSelectRowAt was not being called for the first touch after a reorder. Where in a regular situation this isn't needed, I did require this when I had a tableView inside a view inside a container view.