### PR TITLE
Take into account custom content insets also not only overlapping bars

### DIFF
--- a/Source/ReorderController+AutoScroll.swift
+++ b/Source/ReorderController+AutoScroll.swift
@@ -39,7 +39,7 @@ extension ReorderController {
         
         let safeAreaFrame: CGRect
         if #available(iOS 11, *) {
-            safeAreaFrame = tableView.frame.inset(by: tableView.safeAreaInsets)
+            safeAreaFrame = tableView.frame.inset(by: tableView.adjustedContentInset)
         } else {
             safeAreaFrame = tableView.frame.inset(by: tableView.scrollIndicatorInsets)
         }


### PR DESCRIPTION
Hey I have following setup: table view bounds are larger by 164px for top and by 100px for bottom compare to visible area. I compensated it with `contentInset` top 100 + 64 for nav bar + 2 small spacer and 100 for bottom. There is a `textView` with 55 height at the bottom to which `tableView` is constrained. Runtime values are:

```
tableView.contentInsetAdjustmentBehavior == .never

(lldb) po UIScreen.main.bounds
▿ (0.0, 0.0, 320.0, 568.0)
  ▿ origin : (0.0, 0.0)
    - x : 0.0
    - y : 0.0
  ▿ size : (320.0, 568.0)
    - width : 320.0
    - height : 568.0

(lldb) po tableView.frame
▿ (0.0, -100.0, 320.0, 713.0)
  ▿ origin : (0.0, -100.0)
    - x : 0.0
    - y : -100.0
  ▿ size : (320.0, 713.0)
    - width : 320.0
    - height : 713.0

(lldb) po tableView.contentInset
▿ UIEdgeInsets
  - top : 166.0
  - left : 0.0
  - bottom : 100.0
  - right : 0.0

(lldb) po tableView.safeAreaInsets
▿ UIEdgeInsets
  - top : 64.0
  - left : 0.0
  - bottom : 0.0
  - right : 0.0

(lldb) po tableView.adjustedContentInset
▿ UIEdgeInsets
  - top : 166.0
  - left : 0.0
  - bottom : 100.0
  - right : 0.0
```

So autoscroll mechanism currently doesn't count for custom `contentInset`. This PR is fixing it.