### PR TITLE
avoid cut off shadows while dragging when using shadows on tableview cells

### DIFF
--- a/Source/ReorderController+SnapshotView.swift
+++ b/Source/ReorderController+SnapshotView.swift
@@ -31,6 +31,7 @@ extension ReorderController {
         tableView.reloadRows(at: [indexPath], with: .none)
         
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
+        cell.subviews.forEach { $0.layer.masksToBounds = true }
         let cellFrame = tableView.convert(cell.frame, to: superview)
         
         UIGraphicsBeginImageContextWithOptions(cell.bounds.size, false, 0)


### PR DESCRIPTION
I don't know if this is also useful for you. I cut the shadow layer of each subview with masksToBounds=true to avoid some ugly cut off problems with shadows while dragging the cell. I added this before the creating the snapshot of the cell view. 

Note: This problem only occurs when you use shadows on your tableview cells.