### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftReorder",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "SwiftReorder", targets: ["SwiftReorder"])
+    ],
+    targets: [
+        .target(name: "SwiftReorder", path: "Source")
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM and closes #60.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.