### PR TITLE
Fix/reload data animation glitch fix

### DIFF
--- a/Example/LongListViewController.swift
+++ b/Example/LongListViewController.swift
@@ -23,9 +23,21 @@
 import UIKit
 import SwiftReorder
 
+private extension String {
+    
+    /// Generates random string with spaces.
+    static func random(length: Int, averageWordLength: Int? = nil) -> String {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let spacesCount = averageWordLength == nil ? 0 : letters.count / averageWordLength!
+        let lettersWithSpace = letters.appending(String(repeating: " ", count: spacesCount))
+        return String((0..<length).map{ _ in lettersWithSpace.randomElement()! })
+    }
+}
+
+
 class LongListViewController: UITableViewController {
     
-    var items = (1...50).map { "Item \($0)" }
+    var items = (1...10000).map { _ in String.random(length: Int.random(in: 0...200), averageWordLength: 5) }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -41,6 +53,8 @@ class LongListViewController: UITableViewController {
         title = "Long List"
         
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.estimatedRowHeight = 44
+        tableView.rowHeight = UITableView.automaticDimension
         tableView.allowsSelection = false
         tableView.reorder.delegate = self
     }
@@ -60,6 +74,7 @@ extension LongListViewController {
         
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         cell.textLabel?.text = items[indexPath.row]
+        cell.textLabel?.numberOfLines = 0
         
         return cell
     }

--- a/Source/ReorderController+DestinationRow.swift
+++ b/Source/ReorderController+DestinationRow.swift
@@ -46,10 +46,7 @@ extension ReorderController {
         
         delegate?.tableView(tableView, reorderRowAt: context.destinationRow, to: newContext.destinationRow)
         
-        tableView.beginUpdates()
-        tableView.deleteRows(at: [context.destinationRow], with: .fade)
-        tableView.insertRows(at: [newContext.destinationRow], with: .fade)
-        tableView.endUpdates()
+        tableView.moveRow(at: context.destinationRow, to: newContext.destinationRow)
     }
     
     func proposedNewDestinationRow() -> IndexPath? {

--- a/Source/ReorderController+SnapshotView.swift
+++ b/Source/ReorderController+SnapshotView.swift
@@ -28,7 +28,6 @@ extension ReorderController {
         guard let tableView = tableView, let superview = tableView.superview else { return }
         
         removeSnapshotView()
-        tableView.reloadRows(at: [indexPath], with: .none)
         
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
         let cellFrame = tableView.convert(cell.frame, to: superview)


### PR DESCRIPTION
Fixes https://github.com/adamshin/SwiftReorder/issues/6

Fixed animation glitch when try to reload rows in a long list with dynamic cells. 
You can check a bug here - https://github.com/anton-plebanovich/SwiftReorder/tree/f7afafd9a5518d6b8c06b69f119ef1a64e4a66db
And a fix here - https://github.com/anton-plebanovich/SwiftReorder/tree/9b2744abbd8817769f8fa9335f4e0949f88b91f8